### PR TITLE
Install .go files to $(libdir)/guile

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ dist-hook:
 	cp $(top_srcdir)/pkg-list.scm.in $(top_distdir)/pkg-list.scm
 	sed -i '' "s/%VERSION%/$(PKG_LIST_VERSION)/g" $(top_distdir)/pkg-list.scm
 
-moddir = $(datadir)/guile/site
+moddir = $(datadir)/guile/site/@GUILE_EFFECTIVE_VERSION@
 
 SOURCES = json.scm
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -32,7 +32,7 @@ PKG_LIST_VERSION=$(shell echo $(PACKAGE_VERSION) | sed "s/\./ /g")
 dist-hook:
 	$(SHELL) $(top_srcdir)/ChangeLog > $(top_distdir)/ChangeLog
 	cp $(top_srcdir)/pkg-list.scm.in $(top_distdir)/pkg-list.scm
-	sed -i '' "s/%VERSION%/$(PKG_LIST_VERSION)/g" $(top_distdir)/pkg-list.scm
+	sed -i "s/%VERSION%/$(PKG_LIST_VERSION)/g" $(top_distdir)/pkg-list.scm
 
 moddir = $(datadir)/guile/site/@GUILE_EFFECTIVE_VERSION@
 objdir = $(libdir)/guile/@GUILE_EFFECTIVE_VERSION@/site-ccache

--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ dist-hook:
 	cp $(top_srcdir)/pkg-list.scm.in $(top_distdir)/pkg-list.scm
 	sed -i '' "s/%VERSION%/$(PKG_LIST_VERSION)/g" $(top_distdir)/pkg-list.scm
 
-moddir=$(prefix)/share/guile/site
+moddir = $(datadir)/guile/site
 
 SOURCES = json.scm
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -35,12 +35,14 @@ dist-hook:
 	sed -i '' "s/%VERSION%/$(PKG_LIST_VERSION)/g" $(top_distdir)/pkg-list.scm
 
 moddir = $(datadir)/guile/site/@GUILE_EFFECTIVE_VERSION@
+objdir = $(libdir)/guile/@GUILE_EFFECTIVE_VERSION@/site-ccache
 
 SOURCES = json.scm
-
 GOBJECTS = $(SOURCES:%.scm=%.go)
 
-nobase_mod_DATA = $(SOURCES) $(NOCOMP_SOURCES) $(GOBJECTS)
+nobase_mod_DATA = $(SOURCES) $(NOCOMP_SOURCES)
+nobase_nodist_obj_DATA = $(GOBJECTS)
+
 EXTRA_DIST = $(SOURCES) $(NOCOMP_SOURCES)
 
 CLEANFILES = $(GOBJECTS)

--- a/configure.ac
+++ b/configure.ac
@@ -29,6 +29,13 @@ AC_CONFIG_AUX_DIR([build-aux])
 AM_INIT_AUTOMAKE([color-tests -Wall -Wno-portability])
 AM_SILENT_RULES([yes])
 
+dnl We require pkg.m4 (from pkg-config) and guile.m4 (from Guile.)
+dnl Make sure they are available.
+m4_pattern_forbid([PKG_CHECK_MODULES])
+m4_pattern_forbid([^GUILE_PKG])
+
+dnl Check for Guile 2.x, and substitute 'GUILE_EFFECTIVE_VERSION'.
+GUILE_PKG([2.2 2.0])
 GUILE_PROGS
 
 AC_CONFIG_FILES([Makefile json/Makefile])

--- a/json/Makefile.am
+++ b/json/Makefile.am
@@ -23,7 +23,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #
 
-moddir = $(datadir)/guile/site/json
+moddir = $(datadir)/guile/site/@GUILE_EFFECTIVE_VERSION@/json
 
 SOURCES = builder.scm parser.scm
 

--- a/json/Makefile.am
+++ b/json/Makefile.am
@@ -24,12 +24,15 @@
 #
 
 moddir = $(datadir)/guile/site/@GUILE_EFFECTIVE_VERSION@/json
+objdir = $(libdir)/guile/@GUILE_EFFECTIVE_VERSION@/site-ccache/json
 
 SOURCES = builder.scm parser.scm
 
 GOBJECTS = $(SOURCES:%.scm=%.go)
 
-nobase_mod_DATA = $(SOURCES) $(NOCOMP_SOURCES) $(GOBJECTS)
+nobase_mod_DATA = $(SOURCES) $(NOCOMP_SOURCES)
+nobase_nodist_obj_DATA = $(GOBJECTS)
+
 EXTRA_DIST = $(SOURCES) $(NOCOMP_SOURCES)
 
 CLEANFILES = $(GOBJECTS)

--- a/json/Makefile.am
+++ b/json/Makefile.am
@@ -23,7 +23,7 @@
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA
 #
 
-moddir=$(prefix)/share/guile/site/json
+moddir = $(datadir)/guile/site/json
 
 SOURCES = builder.scm parser.scm
 


### PR DESCRIPTION
Hello Aleix,

These commits have `make install` install `.scm` files to `share/guile/site/2.2` instead of ` share/guile/site`, and move `.go` files to `lib/guile/2.2/site-ccache` (or similar), as per Guile conventions.

Let me know what you think!

Ludo'.