### PR TITLE
add keyword argument to procedure head in readme

### DIFF
--- a/README.org
+++ b/README.org
@@ -80,7 +80,7 @@ the module:
 - (*json-string->scm* str) : Reads a JSON document from the given
   string.
 
-- (*scm->json* native #:optional port #:key escape pretty) : Creates a
+- (*scm->json* native #:optional port #:key escape unicode pretty) : Creates a
   JSON document from the given native Guile value. The JSON document is
   written into the given port, or to the current output port if non is
   given.
@@ -90,7 +90,7 @@ the module:
   - /unicode/ : if true, unicode characters will be escaped when needed.
   - /pretty/ : if true, the JSON document will be pretty printed.
 
-- (*scm->json-string* native #:key escape pretty) : Creates a JSON
+- (*scm->json-string* native #:key escape unicode pretty) : Creates a JSON
   document from the given native Guile value into a string.
 
   - /escape/ : if true, the slash (/ solidus) character will be escaped.


### PR DESCRIPTION
I added the new `#:unicode` keyword argument to the README where it was missing.