### PR TITLE
add a case for building the JSON of empty JSON objects

### DIFF
--- a/README.org
+++ b/README.org
@@ -97,6 +97,9 @@ the module:
   - /unicode/ : if true, unicode characters will be escaped when needed.
   - /pretty/ : if true, the JSON document will be pretty printed.
 
+  Note that when using alists to build JSON objects, symbols or numbers might
+  be used as keys and they both will be converted to strings.
+
 
 ** Exceptions
 

--- a/json/builder.scm
+++ b/json/builder.scm
@@ -191,15 +191,22 @@
 (define* (scm->json scm
                     #:optional (port (current-output-port))
                     #:key (escape #f) (unicode #f) (pretty #f))
-  "Creates a JSON document from native. The argument @var{scm} contains
-the native value of the JSON document. Takes one optional argument,
-@var{port}, which defaults to the current output port where the JSON
-document will be written."
+  "Creates a JSON document from native. The argument @var{scm} contains the
+native value of the JSON document. Takes one optional argument, @var{port},
+which defaults to the current output port where the JSON document will be
+written. It also takes a few key arguments: @var{escape}: if true, the
+slash (/ solidus) character will be escaped, @{unicode} : if true, unicode
+characters will be escaped when needed and @{pretty}: if true, the JSON
+document will be pretty printed.
+
+Note that when using alists to build JSON objects, symbols or numbers might be
+used as keys and they both will be converted to strings.
+"
   (json-build scm port escape unicode pretty 0))
 
 (define* (scm->json-string scm #:key (escape #f) (unicode #f) (pretty #f))
-  "Creates a JSON document from native into a string. The argument
-@var{scm} contains the native value of the JSON document."
+  "Creates a JSON document from native into a string. The argument @var{scm}
+contains the native value of the JSON document."
   (call-with-output-string
    (lambda (p)
      (scm->json scm p #:escape escape #:unicode unicode #:pretty pretty))))

--- a/json/builder.scm
+++ b/json/builder.scm
@@ -182,6 +182,7 @@
    ((string? scm) (json-build-string scm port escape unicode))
    ((vector? scm) (json-build-array scm port escape unicode pretty level))
    ((pair? scm) (json-build-object scm port escape unicode pretty level))
+   ((null? scm) (json-build-object scm port escape unicode pretty level))
    (else (throw 'json-invalid))))
 
 ;;

--- a/tests/test-builder.scm
+++ b/tests/test-builder.scm
@@ -76,6 +76,10 @@
   (scm->json-string '((title . "A book")
                       (author . "An author")
                       (price . 29.99))))
+;; Empty objects
+(test-equal "{}" (scm->json-string '()))
+(test-equal "{\"top-level\":{\"second-level\":{}}}"
+  (scm->json-string '(("top-level" ("second-level")))))
 
 (exit (if (test-end "test-builder") 0 1))
 


### PR DESCRIPTION
This prevents the bug described in https://github.com/aconchillo/guile-json/issues/44.

By adding an additional case, the throwing of an exception is prevented and instead the empty JSON object is correctly build in the problematic case.