### PR TITLE
build: Fix cross-compilation.

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -42,7 +42,7 @@ nobase_nodist_obj_DATA = $(GOBJECTS)
 GUILE_WARNINGS = -Wunbound-variable -Warity-mismatch -Wformat
 SUFFIXES = .scm .go
 .scm.go:
-	$(top_builddir)/env $(GUILD) compile $(GUILE_WARNINGS) -o "$@" "$<"
+	$(top_builddir)/env $(GUILD) compile $(GUILE_TARGET) $(GUILE_WARNINGS) -o "$@" "$<"
 
 SOURCES = json.scm
 

--- a/configure.ac
+++ b/configure.ac
@@ -45,6 +45,11 @@ AC_SUBST(GUILE_LIBDIR)
 AC_CONFIG_FILES([Makefile json/Makefile tests/Makefile])
 AC_CONFIG_FILES([env], [chmod +x env])
 
+if test "$cross_compiling" != no; then
+   GUILE_TARGET="--target=$host_alias"
+   AC_SUBST([GUILE_TARGET])
+fi
+
 AC_OUTPUT
 
 dnl This is just for printing $libdir below.


### PR DESCRIPTION
* configure.ac: Set GUILE_TARGET when cross compiling.
* Makefile.am: Pass it to guild.