### PR TITLE
Fix an issue for scm->json-string conversion

### DIFF
--- a/json/builder.scm
+++ b/json/builder.scm
@@ -122,7 +122,7 @@
   (cond ((char? x) (make-string 1 x))
         ((number? x) (number->string x))
         ((symbol? x) (symbol->string x))
-        (else x)))
+        (else (format #f "~a" x))))
 
 (define (json-build-string scm port escape unicode)
   (display "\"" port)


### PR DESCRIPTION
The `->string` function ,which `json-build-string` depends on, only returns a string if the input is a number, char or symbol. This is causes an issue when converting other a scheme types (e.g records) to JSON and will fail as `string->list` in `json-build-string` expects a string.