### PR TITLE
introduce 'null symbol as default value for JSON null

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,9 +1,8 @@
 
 * guile-json
 
-guile-json is a JSON module for Guile. It supports parsing and
-building JSON documents according to the http://json.org
-specification.
+guile-json is a JSON module for Guile. It supports parsing and building JSON
+documents according to the http://json.org specification.
 
 - Complies with http://json.org specification.
 
@@ -38,21 +37,21 @@ If everything installed successfully you should be up and running:
     : scheme@(guile-user)> (scm->json #(1 2 3))
     : [1,2,3]
 
-It might be that you installed guile-json somewhere differently than
-your system's Guile. If so, you need to indicate Guile where to find
-guile-json, for example:
+It might be that you installed guile-json somewhere differently than your
+system's Guile. If so, you need to indicate Guile where to find guile-json,
+for example:
 
     : $ GUILE_LOAD_PATH=/usr/local/share/guile/site guile
 
-A pkg-list.scm file is also provided for users of the
-Guildhall/Dorodango packaging system.
+A pkg-list.scm file is also provided for users of the Guildhall/Dorodango
+packaging system.
 
 
 * Usage
 
-guile-json provides a few procedures to parse and build a JSON
-document. A JSON document is transformed into or from native Guile
-values according to the following table:
+guile-json provides a few procedures to parse and build a JSON document. A
+JSON document is transformed into or from native Guile values according to the
+following table:
 
 | JSON   | Guile  |
 |--------+--------|
@@ -62,7 +61,12 @@ values according to the following table:
 | array  | vector |
 | true   | #t     |
 | false  | #f     |
-| null   | #nil   |
+| null   | 'null  |
+
+By default the value of JSON "null" is mapped to the symbol 'null. However,
+all guile-json functions allow changing the default null value by specifying
+the #:null keyword argument with another value. This other value needs to be
+recognized by /eq?/.
 
 To start using guile-json procedures and macros you first need to load
 the module:
@@ -72,34 +76,55 @@ the module:
 
 ** Procedures
 
-- (*json->scm* #:optional port) : Reads a JSON document from the given
-  port, or from the current input port if none is given.
+- (*json->scm* #:optional port #:key null) : Reads a JSON document from the
+  given port, or from the current input port if none is given.
+
+  Optional arguments:
 
   - /port/ : is optional, it defaults to the current input port.
 
-- (*json-string->scm* str) : Reads a JSON document from the given
+  Keyword arguments:
+
+  - /null/ : value for JSON's null, it defaults to the 'null symbol.
+
+- (*json-string->scm* str  #:key null) : Reads a JSON document from the given
   string.
 
-- (*scm->json* native #:optional port #:key escape unicode pretty validate) :
+  Keyword arguments:
+
+  - /null/ : value for JSON's null, it defaults to the 'null symbol.
+
+- (*scm->json* native #:optional port #:key escape unicode pretty validate null) :
   Creates a JSON document from the given native Guile value. The JSON document
   is written into the given port, or to the current output port if non is
   given.
 
+  Optional arguments:
+
   - /port/ : it defaults to the current output port.
-  - /escape/ : if true, the slash (/ solidus) character will be escaped.
-  - /unicode/ : if true, unicode characters will be escaped when needed.
+
+  Keyword arguments:
+
+  - /solidus/ : if true, the slash (/ solidus) character will be escaped.
+  - /unicode/ : if true, additional to control characters, non-ASCII
+    characters will be escaped as well.
   - /pretty/ : if true, the JSON document will be pretty printed.
   - /validate/ : if true, the native value will be validated before starting
     to print the JSON document (defaults to true).
+  - /null/ : value for JSON's null, it defaults to the 'null symbol.
 
 - (*scm->json-string* native #:key escape unicode pretty validate) : Creates a
   JSON document from the given native Guile value into a string.
 
+  Keyword arguments:
+
   - /escape/ : if true, the slash (/ solidus) character will be escaped.
-  - /unicode/ : if true, unicode characters will be escaped when needed.
+  - /unicode/ : if true, additional to control characters, non-ASCII
+    characters will be escaped as well.
   - /pretty/ : if true, the JSON document will be pretty printed
   - /validate/ : if true, the native value will be validated before starting
     to print the JSON document (defaults to true).
+  - /null/ : value for JSON's null, it defaults to the 'null symbol.
 
   Note that when using alists to build JSON objects, symbols or numbers might
   be used as keys and they both will be converted to strings.
@@ -121,7 +146,7 @@ supported types).
 
 - Build the string "hello world":
 
-    : > (scm->json "hello world ")
+    : > (scm->json "hello world")
     : "hello world"
 
 - Build the [1, 2, 3] array:
@@ -129,10 +154,14 @@ supported types).
     : > (scm->json #(1 2 3))
     : [1,2,3]
 
-- Build the object { "project" : "foo", "author" : "bar" } using an alist. See
-  how symbols can also be used:
+- Build the object { "project" : "foo", "author" : "bar" } using an alist:
 
-    : > (scm->json '((project . foo) (author . bar)))
+    : > (scm->json '(("project" . "foo") ("author" . "bar")))
+    : {"project":"foo","author":"bar"}
+
+- Build the same object but this time using symbols:
+
+    : > (scm->json '((project . foo) ("author" . "bar")))
     : {"project":"foo","author":"bar"}
 
 - Build the object { "values" : [ 234, 98.56 ] }:
@@ -146,6 +175,16 @@ supported types).
     : > (define values #(234 98.56))
     : > (scm->json `(("values" . ,values)))
     : {"values":[234,98.56]}
+
+- Default null value is the 'null symbol:
+
+    : > (scm->json 'null)
+    : null
+
+- The default null value can be changed to something else:
+
+    : > (scm->json #nil #:null #nil)
+    : null
 
 
 * License

--- a/json/builder.scm
+++ b/json/builder.scm
@@ -33,6 +33,14 @@
   #:export (scm->json
             scm->json-string))
 
+
+;;
+;; Miscellaneuos helpers
+;;
+
+(define (indent-string pretty level)
+  (if pretty (format #f "~v_" (* 2 level)) ""))
+
 ;;
 ;; String builder helpers
 ;;
@@ -83,49 +91,13 @@
      ;; Anything else should wrong, hopefully.
      (else (throw 'json-invalid (string c))))))
 
-;;
-;; Object builder functions
-;;
-
-(define (build-object-pair p port escape unicode pretty level)
-  (put-string port (indent-string pretty level))
-  (json-build-string (car p) port escape unicode)
-  (build-space port pretty)
-  (put-string port ":")
-  (build-space port pretty)
-  (json-build (cdr p) port escape unicode pretty level))
-
-(define (build-newline port pretty)
-  (cond (pretty (newline port))))
-
-(define (build-space port pretty)
-  (cond (pretty (put-string port " "))))
-
-(define (indent-string pretty level)
-  (if pretty (format #f "~v_" (* 2 level)) ""))
-
-;;
-;; Main builder functions
-;;
-
-(define (json-build-null port)
-  (put-string port "null"))
-
-(define (json-build-boolean scm port)
-  (put-string port (if scm "true" "false")))
-
-(define (json-build-number scm port)
-  (if (and (rational? scm) (not (integer? scm)))
-      (put-string port (number->string (exact->inexact scm)))
-      (put-string port (number->string scm))))
-
 (define (->string x)
   (cond ((char? x) (make-string 1 x))
         ((number? x) (number->string x))
         ((symbol? x) (symbol->string x))
         (else x)))
 
-(define (json-build-string scm port escape unicode)
+(define (json-build-string scm port solidus unicode)
   (put-string port "\"")
   (put-string
    port
@@ -140,70 +112,111 @@
                      ((#\lf) '(#\\ #\n))
                      ((#\cr) '(#\\ #\r))
                      ((#\ht) '(#\\ #\t))
-                     ((#\/) (if escape `(#\\ ,c) (list c)))
+                     ((#\/) (if solidus `(#\\ ,c) (list c)))
                      (else (if unicode (string->list (build-char-string c)) (list c)))))
                  (string->list (->string scm))))))
   (put-string port "\""))
 
-(define (json-build-array scm port escape unicode pretty level)
-  (put-string port "[")
-  (unless (null? scm)
-    (vector-for-each (lambda (i v)
-                       (if (> i 0) (put-string port ","))
-                       (build-space port pretty)
-                       (json-build v port escape unicode pretty (+ level 1)))
-                     scm))
-  (put-string port "]"))
+;;
+;; Object builder functions
+;;
 
-(define (json-build-object scm port escape unicode pretty level)
+(define (build-object-pair p port solidus unicode null pretty level)
+  (put-string port (indent-string pretty level))
+  (json-build-string (car p) port solidus unicode)
+  (build-space port pretty)
+  (put-string port ":")
+  (build-space port pretty)
+  (json-build (cdr p) port solidus unicode null pretty level))
+
+(define (build-newline port pretty)
+  (cond (pretty (newline port))))
+
+(define (build-space port pretty)
+  (cond (pretty (put-string port " "))))
+
+(define (json-build-object scm port solidus unicode null pretty level)
   (cond ((> level 0)
          (build-newline port pretty)))
   (simple-format port "~A{" (indent-string pretty level))
   (build-newline port pretty)
   (let ((pairs scm))
     (unless (null? pairs)
-      (build-object-pair (car pairs) port escape unicode pretty (+ level 1))
+      (build-object-pair (car pairs) port solidus unicode null pretty (+ level 1))
       (for-each (lambda (p)
                   (put-string port ",")
                   (build-newline port pretty)
-                  (build-object-pair p port escape unicode pretty (+ level 1)))
+                  (build-object-pair p port solidus unicode null pretty (+ level 1)))
                 (cdr pairs))))
   (build-newline port pretty)
   (simple-format port "~A}" (indent-string pretty level)))
 
+;;
+;; Array builder functions
+;;
+
+(define (json-build-array scm port solidus unicode null pretty level)
+  (put-string port "[")
+  (unless (null? scm)
+    (vector-for-each (lambda (i v)
+                       (if (> i 0) (put-string port ","))
+                       (build-space port pretty)
+                       (json-build v port solidus unicode null pretty (+ level 1)))
+                     scm))
+  (put-string port "]"))
+
+;;
+;; Booleans, null and number builder functions
+;;
+
+(define (json-build-boolean scm port)
+  (put-string port (if scm "true" "false")))
+
+(define (json-build-null port)
+  (put-string port "null"))
+
+(define (json-build-number scm port)
+  (if (and (rational? scm) (not (integer? scm)))
+      (put-string port (number->string (exact->inexact scm)))
+      (put-string port (number->string scm))))
+
+;;
+;; Main builder functions
+;;
+
 (define (json-number? number)
   (and (number? number) (eqv? (imag-part number) 0) (finite? number)))
-
-(define (json-build scm port escape unicode pretty level)
-  (cond
-   ((eq? scm #nil) (json-build-null port))
-   ((boolean? scm) (json-build-boolean scm port))
-   ((json-number? scm) (json-build-number scm port))
-   ((symbol? scm) (json-build-string (symbol->string scm) port escape unicode))
-   ((string? scm) (json-build-string scm port escape unicode))
-   ((vector? scm) (json-build-array scm port escape unicode pretty level))
-   ((or (pair? scm) (null? scm))
-    (json-build-object scm port escape unicode pretty level))
-   (else (throw 'json-invalid scm))))
 
 (define (json-key? scm)
   (or (symbol? scm) (string? scm)))
 
-(define (json-valid? scm)
+(define (json-valid? scm null)
   (cond
-   ((eq? scm #nil) #t)
+   ((eq? scm null) #t)
    ((boolean? scm) #t)
    ((json-number? scm) #t)
    ((symbol? scm) #t)
    ((string? scm) #t)
-   ((vector? scm) (vector-every json-valid? scm))
+   ((vector? scm) (vector-every (lambda (elem) (json-valid? elem null)) scm))
    ((pair? scm)
     (every (lambda (entry)
 	     (and (pair? entry)
 		  (json-key? (car entry))
-		  (json-valid? (cdr entry))))
+		  (json-valid? (cdr entry) null)))
 	   scm))
    ((null? scm) #t)
+   (else (throw 'json-invalid scm))))
+
+(define (json-build scm port solidus unicode null pretty level)
+  (cond
+   ((eq? scm null) (json-build-null port))
+   ((boolean? scm) (json-build-boolean scm port))
+   ((json-number? scm) (json-build-number scm port))
+   ((symbol? scm) (json-build-string (symbol->string scm) port solidus unicode))
+   ((string? scm) (json-build-string scm port solidus unicode))
+   ((vector? scm) (json-build-array scm port solidus unicode null pretty level))
+   ((or (pair? scm) (null? scm))
+    (json-build-object scm port solidus unicode null pretty level))
    (else (throw 'json-invalid scm))))
 
 ;;
@@ -212,33 +225,40 @@
 
 (define* (scm->json scm
                     #:optional (port (current-output-port))
-                    #:key (escape #f) (unicode #f) (pretty #f) (validate #t))
+                    #:key
+                    (solidus #f) (unicode #f) (null 'null)
+                    (pretty #f) (validate #t))
   "Creates a JSON document from native. The argument @var{scm} contains the
 native value of the JSON document. Takes one optional argument, @var{port},
 which defaults to the current output port where the JSON document will be
-written. It also takes a few key arguments: @var{escape}: if true, the
-slash (/ solidus) character will be escaped, @{unicode} : if true, unicode
-characters will be escaped when needed and @{pretty}: if true, the JSON
-document will be pretty printed.
+written. It also takes a few keyword arguments: @{solidus}: if true, the
+slash (/ solidus) character will be escaped, @{unicode}: if true, unicode
+characters will be escaped when needed, @{null}: value for JSON's null, it
+defaults to the 'null symbol and @{pretty}: if true, the JSON document will be
+pretty printed.
 
 Note that when using alists to build JSON objects, symbols or numbers might be
 used as keys and they both will be converted to strings.
 "
   (cond
-   ((and validate (json-valid? scm))
-    (json-build scm port escape unicode pretty 0))
+   ((and validate (json-valid? scm null))
+    (json-build scm port solidus unicode null pretty 0))
    (else
-    (json-build scm port escape unicode pretty 0))))
+    (json-build scm port solidus unicode null pretty 0))))
 
 (define* (scm->json-string scm #:key
-                           (escape #f) (unicode #f)
+                           (solidus #f) (unicode #f) (null 'null)
                            (pretty #f) (validate #f))
   "Creates a JSON document from native into a string. The argument @var{scm}
-contains the native value of the JSON document."
+contains the native value of the JSON document. It also takes a few keyword
+arguments: @{solidus}: if true, the slash (/ solidus) character will be
+escaped, @{unicode}: if true, unicode characters will be escaped when needed,
+@{null}: value for JSON's null, it defaults to the 'null symbol and @{pretty}:
+if true, the JSON document will be pretty printed."
   (call-with-output-string
    (lambda (p)
      (scm->json scm p
-                #:escape escape #:unicode unicode
+                #:solidus solidus #:unicode unicode #:null null
                 #:pretty pretty #:validate validate))))
 
 ;;; (json builder) ends here

--- a/tests/test-builder.scm
+++ b/tests/test-builder.scm
@@ -52,14 +52,15 @@
 (test-equal "\"\\u4f60\\u597d guile!\"" (scm->json-string "你好 guile!" #:unicode #t))
 (test-equal "\"guile powers music \\ud834\\udd1e!\"" (scm->json-string "guile powers music 𝄞!" #:unicode #t))
 (test-equal "\"</script>\"" (scm->json-string "</script>"))
-(test-equal "\"<\\/script>\"" (scm->json-string "</script>" #:escape #t))
+(test-equal "\"<\\/script>\"" (scm->json-string "</script>" #:solidus #t))
 
 ;; Boolean
 (test-equal "true" (scm->json-string #t))
 (test-equal "false" (scm->json-string #f))
 
 ;; Null
-(test-equal "null" (scm->json-string #nil))
+(test-equal "null" (scm->json-string 'null))
+(test-equal "null" (scm->json-string #nil #:null #nil))
 
 ;; Arrays
 (test-equal "[]" (scm->json-string #()))

--- a/tests/test-parser.scm
+++ b/tests/test-parser.scm
@@ -62,7 +62,8 @@
 (test-equal #f (json-string->scm "false"))
 
 ;; Null
-(test-equal #nil (json-string->scm "null"))
+(test-equal 'null (json-string->scm "null"))
+(test-equal #nil (json-string->scm "null" #:null #nil))
 
 ;; Arrays
 (test-equal #() (json-string->scm "[]"))


### PR DESCRIPTION
This patch introduces a breaking change since JSON null is now mapped to the
symbol 'null (see https://github.com/aconchillo/guile-json/issues/31).

However, this default value can be modified in all public function by
providing the #:null key argument.

Fixes #31