### PR TITLE
record: allow unspecified values

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,10 @@
 
 * Version 4.4.0 (??, 2020)
 
+  - Record-JSON mapping now allows using *unspecified* values to indicate a
+    field record should not be serialized.
+    (Fixes #61)
+
   - Improve pretty printing.
     (thanks to Jonas Schürmann)
 

--- a/README.org
+++ b/README.org
@@ -197,6 +197,9 @@ when creating REST APIs.
     - /value->json/ : an optional procedure that will be used to convert the
       the value contained in the record to the JSON value.
 
+When serializing a record to JSON it is possible to set a field to the
+=*unspecified*= value in order to omit it from serialization.
+
 *** Example
 
 - A simple example that defines an account type with two fields: /id/ and

--- a/json/record.scm
+++ b/json/record.scm
@@ -53,7 +53,7 @@ following SPEC, a series of field specifications."
                                      (assoc-ref table key))
                                     ((_ table (field))
                                      (assoc-ref table (symbol->string 'field))))))
-        (ctor (extract-field table spec) ...)))))
+        (ctor (or (extract-field table spec) *unspecified*) ...)))))
 
 (define-syntax-rule (define-json-writer record->json spec ...)
   "Define RECORD->JSON as a procedure that converts a RECORD into its JSON
@@ -68,7 +68,10 @@ representation following SPEC, a series of field specifications."
                                    (cons key (getter record)))
                                   ((_ (field getter))
                                    (cons (symbol->string 'field) (getter record))))))
-      (scm->json-string `(,(extract-field spec) ...)))))
+      (let* ((full-object `(,(extract-field spec) ...))
+             (object (filter (lambda (p) (not (unspecified? (cdr p))))
+                             full-object)))
+        (scm->json-string object)))))
 
 (define-syntax define-json-mapping
   (syntax-rules (<=>)

--- a/tests/test-record.scm
+++ b/tests/test-record.scm
@@ -42,8 +42,8 @@
 
 (define test-json-account
   "{\"id\":\"11111\",\"username\":\"jane\"}")
-(define test-account (json->account test-json-account))
 
+(define test-account (json->account test-json-account))
 (test-equal "11111" (account-id test-account))
 (test-equal "jane" (account-username test-account))
 
@@ -60,8 +60,8 @@
 
 (define test-json-account
   "{\"id\":\"22222\",\"username\":\"john\"}")
-(define test-account (json->account test-json-account))
 
+(define test-account (json->account test-json-account))
 (test-equal "22222" (account-id test-account))
 (test-equal "john" (account-username test-account))
 
@@ -91,10 +91,32 @@
 
 (define test-json-account
   "{\"id\":\"22222\",\"username\":\"john\"}")
-(define test-account (json->account test-json-account))
 
+(define test-account (json->account test-json-account))
 (test-equal "22222" (account-id test-account))
 (test-equal "JOHN" (account-username test-account))
+
+;; Record WITH conversion functions and *unspecified* values.
+(define-json-mapping <account>
+  make-account
+  account?
+  json->account <=> account->json
+  (id       account-id)
+  (username account-username)
+  (omitted  account-omitted))
+
+(define test-json-account
+  "{\"id\":\"11111\",\"username\":\"jane\"}")
+
+(define test-account (json->account test-json-account))
+(test-equal "11111" (account-id test-account))
+(test-equal "jane" (account-username test-account))
+(test-equal *unspecified* (account-omitted test-account))
+
+(define test-account-idem (json->account (account->json test-account)))
+(test-equal "11111" (account-id test-account-idem))
+(test-equal "jane" (account-username test-account-idem))
+(test-equal *unspecified* (account-omitted test-account-idem))
 
 (exit (if (test-end "test-record") 0 1))
 


### PR DESCRIPTION
In other languages it's possible to ignore empty/null JSON fields when
building the resulting JSON object. For example, in Go you would specify
`omitempty` in the struct field's tag. In Java, you would use
"@JsonInclude(Include.NON_NULL)" on a field or class to indicate that null
fields should not be serialized.

So, when using records as object with guile-json you can no set a field
to *unspecified*. When that happens the field won't be serialzied to JSON.

* json/record.scm (define-json-writer): ignore fields with *unspecified*
values.

* json/record.scm (define-json-reader): assign *unspecified* if field not
found in object's alist.