### PR TITLE
Make test suites portable accross Guile versions

### DIFF
--- a/tests/test-builder.scm
+++ b/tests/test-builder.scm
@@ -122,6 +122,8 @@
 (test-error #t (scm->json #(1 +inf.0 3)))
 (test-error #t (scm->json '((foo . +nan.0))))
 
-(exit (zero? (test-runner-fail-count (test-end "test-builder"))))
+(let ((fail-count (test-runner-fail-count (test-runner-current))))
+  (test-end "test-builder")
+  (exit (zero? fail-count)))
 
 ;;; (tests test-builder) ends here

--- a/tests/test-parser.scm
+++ b/tests/test-parser.scm
@@ -111,6 +111,8 @@
 (test-error #t (json-string->scm "[1,2,3] extra"))
 (test-error #t (json-string->scm "{} extra"))
 
-(exit (zero? (test-runner-fail-count (test-end "test-parser"))))
+(let ((fail-count (test-runner-fail-count (test-runner-current))))
+  (test-end "test-parser")
+  (exit (zero? fail-count)))
 
 ;;; (tests test-parser) ends here

--- a/tests/test-record.scm
+++ b/tests/test-record.scm
@@ -206,6 +206,8 @@
 (test-equal "{\"id\":\"11111\",\"username\":\"jane\",\"links\":[{\"type\":\"test\",\"url\":\"http://guile.json\"}]}"
   (account-type->json test-account-type))
 
-(exit (zero? (test-runner-fail-count (test-end "test-record"))))
+(let ((fail-count (test-runner-fail-count (test-runner-current))))
+  (test-end "test-record")
+  (exit (zero? fail-count)))
 
 ;;; (tests test-record) ends here


### PR DESCRIPTION
My previous contribution #73 should break tests on Guiles without [this commit](https://git.savannah.gnu.org/cgit/guile.git/commit/?id=de5d1a7f99b8e952b115237ebc29633062f99bb9), I am sorry for the rash PR.