### PR TITLE
parser: Fix json-seq->scm #:handle-truncation 'throw.

### DIFF
--- a/json/parser.scm
+++ b/json/parser.scm
@@ -437,7 +437,7 @@ corrupted fragment and return the next entry), 'replace (skip corrupted fragment
 and return @{truncated-object} instead)."
   (letrec ((handle-truncation
             (case handle-truncate
-              ((throw) (json-exception port))
+              ((throw) json-exception)
               ((stop) (const (eof-object)))
               ((skip)
                (lambda (port)


### PR DESCRIPTION
To not always raise an exception, but just raise one if there's truncation.