### PR TITLE
Handling of duplicate keys in objects

### DIFF
--- a/json/parser.scm
+++ b/json/parser.scm
@@ -210,6 +210,12 @@
        ;; Anything other than colon is an error.
        (else (json-exception port))))))
 
+(define (uniquify-keys pairs res)
+  (cond ((null? pairs) res)
+        ((assoc (caar pairs) res)
+         (uniquify-keys (cdr pairs) res))
+        (#t (uniquify-keys (cdr pairs) (cons (car pairs) res)))))
+
 (define (json-read-object port null ordered)
   (expect-delimiter port #\{)
   (let loop ((pairs '()) (added #t))
@@ -220,7 +226,7 @@
        ((eqv? ch #\})
         (read-char port)
         (cond
-         (added (if ordered (reverse! pairs) pairs))
+         (added (uniquify-keys (if ordered (reverse! pairs) pairs) '()))
          (else (json-exception port))))
        ;; Read one pair and continue.
        ((eqv? ch #\")

--- a/json/parser.scm
+++ b/json/parser.scm
@@ -226,7 +226,9 @@
        ((eqv? ch #\})
         (read-char port)
         (cond
-         (added (uniquify-keys (if ordered (reverse! pairs) pairs) '()))
+         (added (if ordered
+                    (uniquify-keys pairs '())
+                    (reverse! (uniquify-keys pairs '()))))
          (else (json-exception port))))
        ;; Read one pair and continue.
        ((eqv? ch #\")

--- a/json/parser.scm
+++ b/json/parser.scm
@@ -214,7 +214,7 @@
   (cond ((null? pairs) res)
         ((assoc (caar pairs) res)
          (uniquify-keys (cdr pairs) res))
-        (#t (uniquify-keys (cdr pairs) (cons (car pairs) res)))))
+        (else (uniquify-keys (cdr pairs) (cons (car pairs) res)))))
 
 (define (json-read-object port null ordered)
   (expect-delimiter port #\{)

--- a/tests/test-parser.scm
+++ b/tests/test-parser.scm
@@ -86,6 +86,7 @@
 (test-error #t (json-string->scm "[,1]"))
 (test-error #t (json-string->scm "[1,2,,,5]"))
 (test-error #t (json-string->scm "[1,2"))
+(test-error #t (json-string->scm "[1,2,]"))
 
 ;; Objects
 (test-equal '() (json-string->scm "{}"))
@@ -101,6 +102,11 @@
 ;; Objects (ordered)
 (test-equal '() (json-string->scm "{}" #:ordered #t))
 (test-equal '(("green" . 1) ("eggs" . 2) ("ham" . 3)) (json-string->scm "{\"green\":1, \"eggs\":2, \"ham\":3}" #:ordered #t))
+
+;; Objects with duplicate keys
+(test-equal '(("bar" . 2) ("baz" . #(1 2 3)) ("foo" . "last")) (json-string->scm "{\"foo\": \"first\", \"bar\": 2, \"foo\": \"second\", \"baz\": [1, 2, 3], \"foo\": \"last\"}" #:ordered #t))
+
+(test-equal '(("foo" . "last") ("baz" . #(1 2 3)) ("bar" . 2)) (json-string->scm "{\"foo\": \"first\", \"bar\": 2, \"foo\": \"second\", \"baz\": [1, 2, 3], \"foo\": \"last\"}" ))
 
 ;; Since the following JSON object contains more than one key-value pair, we
 ;; can't use "test-equal" directly since the output could be unordered.


### PR DESCRIPTION
Here is the promised pull request for the handling of duplicate keys. This is just a linear pass over the parsed object keeping the last value if a key has been seen before. As I mentioned in #84 this will probably have a performance impact if the objects are large, but I have not tested. I also added a few tests that make sure that this change behaves reasonably.

As a general conclusion I think that this change does not play very well with the ordered concept in the library (see the expected values of the two tests I added), but I do believe this is the best we can do with respect to correctness. 

For performance we might be able to use some more efficient data structure (a hash table comes to mind) but this would probably require more extensive changes in the parser.