### PR TITLE
support for handling duplicate keys

### DIFF
--- a/tests/test-parser.scm
+++ b/tests/test-parser.scm
@@ -1,6 +1,6 @@
 ;;; (tests test-parser) --- Guile JSON implementation.
 
-;; Copyright (C) 2018-2022 Aleix Conchillo Flaque <aconchillo@gmail.com>
+;; Copyright (C) 2018-2023 Aleix Conchillo Flaque <aconchillo@gmail.com>
 ;;
 ;; This file is part of guile-json.
 ;;
@@ -86,6 +86,7 @@
 (test-error #t (json-string->scm "[,1]"))
 (test-error #t (json-string->scm "[1,2,,,5]"))
 (test-error #t (json-string->scm "[1,2"))
+(test-error #t (json-string->scm "[1,2,]"))
 
 ;; Objects
 (test-equal '() (json-string->scm "{}"))
@@ -101,6 +102,9 @@
 ;; Objects (ordered)
 (test-equal '() (json-string->scm "{}" #:ordered #t))
 (test-equal '(("green" . 1) ("eggs" . 2) ("ham" . 3)) (json-string->scm "{\"green\":1, \"eggs\":2, \"ham\":3}" #:ordered #t))
+
+;; Objects with duplicate keys
+(test-equal '(("foo" . "last") ("bar" . 2) ("baz" . #(1 2 3))) (json-string->scm "{\"foo\": \"first\", \"bar\": 2, \"foo\": \"second\", \"baz\": [1, 2, 3], \"foo\": \"last\"}" #:ordered #t))
 
 ;; Since the following JSON object contains more than one key-value pair, we
 ;; can't use "test-equal" directly since the output could be unordered.


### PR DESCRIPTION
This patch adds support for handling duplicate keys. If a duplicate key is found in an object the last value will be used. If #ordered is used, the first appearance of the key is considered in the order.

Fixes #84