### PR TITLE
Added `manifest.scm` file for Guix users.

### DIFF
--- a/manifest.scm
+++ b/manifest.scm
@@ -1,0 +1,13 @@
+;; What follows is a "manifest" equivalent to the command line you gave.
+;; You can store it in a file that you may then pass to any 'guix' command
+;; that accepts a '--manifest' (or '-m') option.
+
+(concatenate-manifests
+  (list (specifications->manifest
+          (list "autoconf"
+                "automake"
+                "make"
+                "pkg-config"
+                "guile"))
+        (package->development-manifest
+          (specification->package "guile"))))


### PR DESCRIPTION
Generated from the following: `guix shell --export-manifest -D guile autoconf automake make pkg-config guile`.

What this means is that Guix users can `git clone` the repository, `cd guile-json`, then `guix shell -m manifest.scm` to generate an environment suitable for building. Then commands as per the README can be run to build the project.