### PR TITLE
Introduce JSON <-> GOOPS objects mapping.

### DIFF
--- a/json/Makefile.am
+++ b/json/Makefile.am
@@ -22,7 +22,7 @@
 moddir=$(datadir)/guile/site/$(GUILE_EFFECTIVE_VERSION)/json
 objdir=$(libdir)/guile/$(GUILE_EFFECTIVE_VERSION)/site-ccache/json
 
-SOURCES = builder.scm parser.scm record.scm
+SOURCES = builder.scm goops.scm parser.scm record.scm
 
 GOBJECTS = $(SOURCES:%.scm=%.go)
 

--- a/json/goops.scm
+++ b/json/goops.scm
@@ -1,0 +1,264 @@
+;;; (json goops) --- Guile JSON implementation.
+
+;; Copyright (C) 2025 Iakob Davitis Dze Gogichaishvili <iakob.gogichaishvili@gmail.com>
+;;
+;; This file is part of guile-json.
+;;
+;; guile-json is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; guile-json is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with guile-json. If not, see https://www.gnu.org/licenses/.
+
+;;; Commentary:
+
+;; JSON module for Guile
+
+;;; Code:
+
+(define-module (json goops)
+  #:use-module (json builder)
+  #:use-module (json parser)
+  #:use-module (oop goops)
+  #:use-module (rnrs base)
+  #:export (scm->object!
+            scm->object
+            json->object!
+            json->object
+
+            object->scm
+            object->json
+
+            slot-json-serializable?
+            slot-json-deserializable?
+            slot-json-key
+            slot-json-serializer
+            slot-json-deserializer
+            slot-definition-type))
+
+;;
+;; Helper Macros/Procedures/Variables
+;;
+
+(define-syntax-rule (define-generic-with-docs name docs)
+  "Define a generic function with documentation."
+  (begin
+    (define-generic name)
+    (set-procedure-property! name 'documentation docs)))
+
+(define protected-scm-types
+  (list <string>
+        <vector>
+        <symbol>
+        <boolean>
+        <real>))
+
+(define-generic type->serializer)
+(define-generic type->deserializer)
+
+;;
+;; Class Introspection
+;;
+
+;; NOTE: These procedures are called `slot-{field}` and not
+;; `slot-definition-{field}` because if the option doesn't exist on the slot,
+;; they subtitute in a default value, which isn't how the `slot-definition-*`
+;; procedures behave.
+(define (slot-json-serializable? slot)
+  (get-keyword #:json-serializable? (slot-definition-options slot) #t))
+(define (slot-json-deserializable? slot)
+  (get-keyword #:json-deserializable? (slot-definition-options slot) #t))
+
+(define (slot-json-key slot)
+  (get-keyword #:json-key (slot-definition-options slot)
+               (symbol->string (slot-definition-name slot))))
+
+(define (slot-definition-type slot)
+  (get-keyword #:type (slot-definition-options slot) #f))
+
+(define (slot-json-serializer slot)
+  (or (get-keyword #:json-serializer (slot-definition-options slot) #f)
+      (and=> (slot-definition-type slot)
+             type->serializer)
+      identity))
+(define (slot-json-deserializer slot)
+  (or (get-keyword #:json-deserializer (slot-definition-options slot) #f)
+      (and=> (slot-definition-type slot)
+             type->deserializer)
+      identity))
+
+;;
+;; Document -> Object
+;;
+
+(define (scm->object! object scm)
+  "Read into class object @var{object} the values in the parsed Scheme format
+JSON document contained in @var{scm}.
+
+The slot definition options control the changes made to the class object from
+the JSON document are identical to what's used by @code{scm->object}."
+  (for-each (lambda (slot)
+              (when (slot-json-deserializable? slot)
+                (let* ((slot-name (slot-definition-name slot))
+                       (key (slot-json-key slot))
+                       (deserialize (slot-json-deserializer slot))
+                       (assoc-value (assoc key scm)))
+                  (when (pair? assoc-value)
+                    (slot-set! object slot-name
+                               (deserialize (cdr assoc-value)))))))
+            (class-slots (class-of object)))
+  object)
+
+(define-generic-with-docs scm->object
+  "Create an object of @var{class} from the parsed Scheme format JSON document
+contained in @var{scm}.
+
+The following slot definition options control the creation of the class object
+from the JSON document:
+@itemize
+@item @code{#:json-deserializable?}: Whether to insert the corresponding value
+from the document into the slot.
+@item @code{#:json-deserializer}: The procedure that will be applied to the value
+in the document before it is inserted into the slot.
+@item @code{#:json-key}: A different object key instead of the slot name that
+the slot value will be read from.
+@end")
+
+(define-method (scm->object (class <class>) (scm <list>))
+  (scm->object! (make class) scm))
+
+(for-each (lambda (type)
+            (add-method! scm->object
+                         (make <method>
+                           #:specializers (list <class> type)
+                           #:procedure (lambda (a b) b))))
+          protected-scm-types)
+
+(define-method (type->deserializer (type <class>))
+  (lambda (scm)
+    (scm->object type scm)))
+
+(define-method (type->deserializer (type <vector>))
+  (define class (vector-ref type 0))
+  (lambda (scm)
+    (vector-map (lambda (element)
+                  (scm->object class element))
+                scm)))
+
+(define-method (type->deserializer (type <list>))
+  (compose vector->list (type->deserializer (list->vector type))))
+
+(define-generic-with-docs json->object!
+  "Read into class object @var{object} from the JSON document provided by
+@var{input}, which can be a string or a port containing a JSON document, or a
+JSON document in parsed Scheme format.
+
+The slot definition options control the changes made to the class object from
+the JSON document are identical to what's used by @code{json->object}.")
+
+(define-method (json->object! object (input <port>))
+  (scm->object! object (json->scm input)))
+(define-method (json->object! object (str <string>))
+  (scm->object! object (json-string->scm str)))
+(define-method (json->object! object (scm <list>))
+  (scm->object! object scm))
+
+(define (json->object class input)
+  "Create an object of @var{class} from the JSON document provided by
+@var{input}, which can be a string or a port containing a JSON document, or a
+JSON document in parsed Scheme format.
+
+The following slot definition options control the creation of the class object
+from the JSON document:
+@itemize
+@item @code{#:json-deserializable?}: Whether to insert the corresponding value
+from the document into the slot.
+@item @code{#:json-deserializer}: The procedure that will be applied to the value
+in the document before it is inserted into the slot.
+@item @code{#:json-key}: A different object key instead of the slot name that
+the slot value will be read from.
+@end"
+  (json->object! (make class) input))
+
+;;
+;; Object -> Document
+;;
+
+(define-generic-with-docs object->scm
+  "Create a JSON document in Scheme format from class object @var{object}.
+
+The following slot definition options control the creation of the document from
+the class object:
+@itemize
+@item @code{#:json-serializable?}: Whether to insert the slot into the document.
+@item @code{#:json-serializer}: The procedure that will be applied to the value
+of the slot before it is serialized and inserted into the document.
+@item @code{#:json-key}: A different object key instead of the slot name that
+the slot value will be inserted into.
+@end")
+
+(define-method (object->scm (object <object>))
+  (define class (class-of object))
+  (let loop ((table '())
+             (slots (class-slots class)))
+    (if (pair? slots)
+        (let ((slot (car slots)))
+          (if (and (slot-bound? object (slot-definition-name slot))
+                   (slot-json-serializable? slot))
+              (let* ((slot-name (slot-definition-name slot))
+                     (key (slot-json-key slot))
+                     (serialize (slot-json-serializer slot))
+                     (serialized-value (serialize (slot-ref object slot-name))))
+                (loop (cons `(,key . ,serialized-value)
+                            table)
+                      (cdr slots)))
+              (loop table (cdr slots))))
+        (reverse table))))
+
+(for-each (lambda (type)
+            (add-method! object->scm
+                         (make <method>
+                           #:specializers (list type)
+                           #:procedure identity)))
+          protected-scm-types)
+
+(define-method (type->serializer (type <class>))
+  object->scm)
+
+(define-method (type->serializer (type <vector>))
+  (lambda (vec)
+    (vector-map object->scm vec)))
+
+(define-method (type->serializer (type <list>))
+  (lambda (vec)
+    (list->vector
+     (map object->scm vec))))
+
+(define* (object->json object #:optional (port #f))
+  "Create a JSON document from class object @var{object}. Takes one optional
+argument @var{port}, which defaults to @code{#f} meaning that the document will
+be returned as a string. If a port is supplied instead, the document will be
+written to that port.
+
+The following slot definition options control the serialization of the JSON
+document from the class object:
+@itemize
+@item @code{#:json-serializable?}: Whether to insert the slot into the document.
+@item @code{#:json-serializer}: The procedure that will be applied to the value
+of the slot before it is serialized and inserted into the document.
+@item @code{#:json-key}: A different object key instead of the slot name that
+the slot value will be inserted into.
+@end"
+  (define scm (object->scm object))
+  (if port
+      (scm->json scm port)
+      (scm->json-string scm)))
+
+;;; (json goops) ends here

--- a/json/goops.scm
+++ b/json/goops.scm
@@ -139,6 +139,8 @@ list/vector of values of that type. If both @code{#:json-deserializer} and
 (define-method (scm->object (class <class>) (scm <list>))
   (scm->object! (make class) scm))
 
+;; For the types present in a JSON document other than alists, let the value pass
+;; through.
 (for-each (lambda (type)
             (add-method! scm->object
                          (make <method>
@@ -146,10 +148,12 @@ list/vector of values of that type. If both @code{#:json-deserializer} and
                            #:procedure (lambda (a b) b))))
           protected-scm-types)
 
+;; (slot-name ... #:type <some-type>)
 (define-method (type->deserializer (type <class>))
   (lambda (scm)
     (scm->object type scm)))
 
+;; (slot-name ... #:type (vector <some-type>))
 (define-method (type->deserializer (type <vector>))
   (define class (vector-ref type 0))
   (lambda (scm)
@@ -157,6 +161,7 @@ list/vector of values of that type. If both @code{#:json-deserializer} and
                   (scm->object class element))
                 scm)))
 
+;; (slot-name ... #:type (list <some-type>))
 (define-method (type->deserializer (type <list>))
   (compose vector->list (type->deserializer (list->vector type))))
 
@@ -237,6 +242,8 @@ and @code{#:type} are present, the former will take precedence.
               (loop table (cdr slots))))
         (reverse table))))
 
+;; For the types present in a JSON document other than alists, let the value pass
+;; through.
 (for-each (lambda (type)
             (add-method! object->scm
                          (make <method>
@@ -244,13 +251,16 @@ and @code{#:type} are present, the former will take precedence.
                            #:procedure identity)))
           protected-scm-types)
 
+;; (slot-name ... #:type <some-type>)
 (define-method (type->serializer (type <class>))
   object->scm)
 
+;; (slot-name ... #:type (vector <some-type>))
 (define-method (type->serializer (type <vector>))
   (lambda (vec)
     (vector-map object->scm vec)))
 
+;; (slot-name ... #:type (list <some-type>))
 (define-method (type->serializer (type <list>))
   (lambda (vec)
     (list->vector

--- a/json/goops.scm
+++ b/json/goops.scm
@@ -99,11 +99,11 @@
 ;;
 
 (define (scm->object! object scm)
-  "Read into class object @var{object} the values in the parsed Scheme format
-JSON document contained in @var{scm}.
+  "Read into object @var{object} the data in the Scheme-formatted JSON document
+contained in @var{scm}.
 
-The slot definition options control the changes made to the class object from
-the JSON document are identical to what's used by @code{scm->object}."
+The slot definition options that control the changes made to the class object
+from the JSON document are identical to what's used by @code{scm->object}."
   (for-each (lambda (slot)
               (when (slot-json-deserializable? slot)
                 (let* ((slot-name (slot-definition-name slot))
@@ -117,7 +117,7 @@ the JSON document are identical to what's used by @code{scm->object}."
   object)
 
 (define-generic-with-docs scm->object
-  "Create an object of @var{class} from the parsed Scheme format JSON document
+  "Create an object of @var{class} from the Scheme-formatted JSON document
 contained in @var{scm}.
 
 The following slot definition options control the creation of the class object
@@ -127,8 +127,8 @@ from the JSON document:
 from the document into the slot.
 @item @code{#:json-deserializer}: The procedure that will be applied to the value
 in the document before it is inserted into the slot.
-@item @code{#:json-key}: A different object key instead of the slot name that
-the slot value will be read from.
+@item @code{#:json-key}: A different object field instead of the slot name in the
+document that will the slot value will be retrieved from.
 @end")
 
 (define-method (scm->object (class <class>) (scm <list>))
@@ -156,7 +156,7 @@ the slot value will be read from.
   (compose vector->list (type->deserializer (list->vector type))))
 
 (define-generic-with-docs json->object!
-  "Read into class object @var{object} from the JSON document provided by
+  "Read into class object @var{object} the data in the JSON document provided by
 @var{input}, which can be a string or a port containing a JSON document, or a
 JSON document in parsed Scheme format.
 
@@ -171,7 +171,7 @@ the JSON document are identical to what's used by @code{json->object}.")
   (scm->object! object scm))
 
 (define (json->object class input)
-  "Create an object of @var{class} from the JSON document provided by
+  "Create an instance @var{class} with data from the JSON document provided by
 @var{input}, which can be a string or a port containing a JSON document, or a
 JSON document in parsed Scheme format.
 
@@ -182,8 +182,8 @@ from the JSON document:
 from the document into the slot.
 @item @code{#:json-deserializer}: The procedure that will be applied to the value
 in the document before it is inserted into the slot.
-@item @code{#:json-key}: A different object key instead of the slot name that
-the slot value will be read from.
+@item @code{#:json-key}: A different object field instead of the slot name in the
+document that will the slot value will be retrieved from.
 @end"
   (json->object! (make class) input))
 
@@ -192,7 +192,7 @@ the slot value will be read from.
 ;;
 
 (define-generic-with-docs object->scm
-  "Create a JSON document in Scheme format from class object @var{object}.
+  "Create a JSON document in Scheme format from the data of object @var{object}.
 
 The following slot definition options control the creation of the document from
 the class object:
@@ -200,8 +200,8 @@ the class object:
 @item @code{#:json-serializable?}: Whether to insert the slot into the document.
 @item @code{#:json-serializer}: The procedure that will be applied to the value
 of the slot before it is serialized and inserted into the document.
-@item @code{#:json-key}: A different object key instead of the slot name that
-the slot value will be inserted into.
+@item @code{#:json-key}: A different field in the document instead of the slot
+name that the slot value will be inserted into.
 @end")
 
 (define-method (object->scm (object <object>))
@@ -242,10 +242,10 @@ the slot value will be inserted into.
      (map object->scm vec))))
 
 (define* (object->json object #:optional (port #f))
-  "Create a JSON document from class object @var{object}. Takes one optional
-argument @var{port}, which defaults to @code{#f} meaning that the document will
-be returned as a string. If a port is supplied instead, the document will be
-written to that port.
+  "Create a JSON document from the data of object @var{object}. Takes one
+optional argument @var{port}, which defaults to @code{#f} meaning that the
+document will be returned as a string. If a port is supplied instead, the
+document will be written to that port.
 
 The following slot definition options control the serialization of the JSON
 document from the class object:
@@ -253,8 +253,8 @@ document from the class object:
 @item @code{#:json-serializable?}: Whether to insert the slot into the document.
 @item @code{#:json-serializer}: The procedure that will be applied to the value
 of the slot before it is serialized and inserted into the document.
-@item @code{#:json-key}: A different object key instead of the slot name that
-the slot value will be inserted into.
+@item @code{#:json-key}: A different field in the document instead of the slot
+name that the slot value will be inserted into.
 @end"
   (define scm (object->scm object))
   (if port

--- a/json/goops.scm
+++ b/json/goops.scm
@@ -128,7 +128,7 @@ from the document into the slot.
 @item @code{#:json-deserializer}: The procedure that will be applied to the value
 in the document before it is inserted into the slot.
 @item @code{#:json-key}: A different object field instead of the slot name in the
-document that will the slot value will be retrieved from.
+document that the slot value will be retrieved from.
 @item @code{#:type}: A class type that the value from the document will be
 deserialized into. If the value in this slot definition option is a list/vector
 of the type, then the value in the document will be deserialized into a
@@ -188,7 +188,7 @@ from the document into the slot.
 @item @code{#:json-deserializer}: The procedure that will be applied to the value
 in the document before it is inserted into the slot.
 @item @code{#:json-key}: A different object field instead of the slot name in the
-document that will the slot value will be retrieved from.
+document that the slot value will be retrieved from.
 @item @code{#:type}: A class type that the value from the document will be
 deserialized into. If the value in this slot definition option is a list/vector
 of the type, then the value in the document will be deserialized into a

--- a/json/goops.scm
+++ b/json/goops.scm
@@ -129,6 +129,11 @@ from the document into the slot.
 in the document before it is inserted into the slot.
 @item @code{#:json-key}: A different object field instead of the slot name in the
 document that will the slot value will be retrieved from.
+@item @code{#:type}: A class type that the value from the document will be
+deserialized into. If the value in this slot definition option is a list/vector
+of the type, then the value in the document will be deserialized into a
+list/vector of values of that type. If both @code{#:json-deserializer} and
+@code{#:type} are present, the former will take precedence.
 @end")
 
 (define-method (scm->object (class <class>) (scm <list>))
@@ -184,6 +189,11 @@ from the document into the slot.
 in the document before it is inserted into the slot.
 @item @code{#:json-key}: A different object field instead of the slot name in the
 document that will the slot value will be retrieved from.
+@item @code{#:type}: A class type that the value from the document will be
+deserialized into. If the value in this slot definition option is a list/vector
+of the type, then the value in the document will be deserialized into a
+list/vector of values of that type. If both @code{#:json-deserializer} and
+@code{#:type} are present, the former will take precedence.
 @end"
   (json->object! (make class) input))
 
@@ -202,6 +212,11 @@ the class object:
 of the slot before it is serialized and inserted into the document.
 @item @code{#:json-key}: A different field in the document instead of the slot
 name that the slot value will be inserted into.
+@item @code{#:type}: A class type that the value in the document will be
+serialized from. If the value in this slot definition option is a list/vector
+of the type, then the value in the document will be serialized from a list/vector
+of values of that type contained in the slot. If both @code{#:json-serializer}
+and @code{#:type} are present, the former will take precedence.
 @end")
 
 (define-method (object->scm (object <object>))
@@ -255,6 +270,11 @@ document from the class object:
 of the slot before it is serialized and inserted into the document.
 @item @code{#:json-key}: A different field in the document instead of the slot
 name that the slot value will be inserted into.
+@item @code{#:type}: A class type that the value in the document will be
+serialized from. If the value in this slot definition option is a list/vector
+of the type, then the value in the document will be serialized from a list/vector
+of values of that type contained in the slot. If both @code{#:json-serializer}
+and @code{#:type} are present, the former will take precedence.
 @end"
   (define scm (object->scm object))
   (if port

--- a/json/goops.scm
+++ b/json/goops.scm
@@ -164,7 +164,12 @@ list/vector of values of that type. If both @code{#:json-deserializer} and
 
 ;; (slot-name ... #:type (list <some-type>))
 (define-method (type->deserializer (type <list>))
-  (compose vector->list (type->deserializer (list->vector type))))
+  (define class (car type))
+  (lambda (scm)
+    (vector->list
+     (vector-map (lambda (element)
+                   (scm->object class element))
+                 scm))))
 
 (define-generic-with-docs json->object!
   "Read into class object @var{object} the data in the JSON document provided by

--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -19,7 +19,7 @@
 # along with guile-json. If not, see https://www.gnu.org/licenses/.
 #
 
-TESTS = test-builder.scm test-parser.scm test-record.scm
+TESTS = test-builder.scm test-goops.scm test-parser.scm test-record.scm
 
 TEST_EXTENSIONS = .scm
 

--- a/tests/test-goops.scm
+++ b/tests/test-goops.scm
@@ -1,0 +1,259 @@
+;;; (tests test-goops) --- Guile JSON implementation.
+
+;; Copyright (C) 2020-2022 Aleix Conchillo Flaque <aconchillo@gmail.com>
+;; Copyright (C) 2025 Iakob Davitis Dze Gogichaishvili <iakob.gogichaishvili@gmail.com>
+;;
+;; This file is part of guile-json.
+;;
+;; guile-json is free software: you can redistribute it and/or modify
+;; it under the terms of the GNU General Public License as published by
+;; the Free Software Foundation; either version 3 of the License, or
+;; (at your option) any later version.
+;;
+;; guile-json is distributed in the hope that it will be useful, but
+;; WITHOUT ANY WARRANTY; without even the implied warranty of
+;; MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+;; General Public License for more details.
+;;
+;; You should have received a copy of the GNU General Public License
+;; along with guile-json. If not, see https://www.gnu.org/licenses/.
+
+;;; Commentary:
+
+;; Unit tests the JSON GOOPS mapping
+
+;;; Code:
+
+(define-module (tests test-goops)
+  #:use-module (oop goops)
+  #:use-module (srfi srfi-1)
+  #:use-module (srfi srfi-64)
+  #:use-module (srfi srfi-43)
+  #:use-module (json)
+  #:use-module (json goops)
+  #:use-module (tests runner))
+
+;; Define a comparable superclass for use with `test-equal', because classes
+;; can't be compared with `equal?' by default.
+(define-class <comparable> ())
+
+(define-method (equal? (x <comparable>) (y <comparable>))
+  (and (eq? (class-of x) (class-of y))
+       (let* ((slots (class-slots (class-of x)))
+              (slot-names (map slot-definition-name slots)))
+         (every (lambda (slot)
+                  (false-if-exception
+                   (equal? (slot-ref x slot)
+                           (slot-ref y slot))))
+                slot-names))))
+
+(test-runner-factory json:test-runner)
+
+(test-begin "test-goops")
+
+;; Class WITHOUT specific field names.
+(define-class <account> (<comparable>)
+  (id       #:init-keyword #:id       #:accessor !id)
+  (username #:init-keyword #:username #:accessor !username))
+
+(test-equal "{\"id\":\"11111\",\"username\":\"jane\"}"
+  (object->json (make <account> #:id "11111" #:username "jane")))
+
+(define test-json-account
+  "{\"id\":\"22222\",\"username\":\"john\"}")
+
+(define test-account (json->object <account> test-json-account))
+
+(test-equal "22222" (!id test-account))
+(test-equal "john" (!username test-account))
+
+;; Class WITH specific field names.
+(define-class <account> (<comparable>)
+  (id       #:init-keyword #:id       #:json-key "account_id")
+  (username #:init-keyword #:username #:json-key "account_username"))
+
+(test-equal "{\"account_id\":\"11111\",\"account_username\":\"user\"}"
+  (object->json (make <account> #:id "11111" #:username "user")))
+
+;; Class WITH conversion functions.
+(define-class <account> (<comparable>)
+  (id       #:init-keyword #:id #:accessor !id)
+  (username #:init-keyword #:username #:accessor !username
+            #:json-deserializer string-upcase
+            #:json-serializer string-downcase))
+
+(test-equal "{\"id\":\"11111\",\"username\":\"jane\"}"
+  (object->json (make <account> #:id "11111" #:username "JANE")))
+
+(define test-json-account
+  "{\"id\":\"22222\",\"username\":\"john\"}")
+
+(define test-account (json->object <account> test-json-account))
+(test-equal "22222" (!id test-account))
+(test-equal "JOHN" (!username test-account))
+
+;; Class WITH conversion functions and unbound values.
+(define-class <account> (<comparable>)
+  (id       #:accessor !id)
+  (username #:accessor !username)
+  (omitted  #:accessor !omitted)
+  (boolean  #:accessor !boolean))
+
+(define test-json-account
+  "{\"id\":\"11111\",\"username\":\"jane\",\"boolean\":false}")
+
+(define test-account (json->object <account> test-json-account))
+(test-equal "11111" (!id test-account))
+(test-equal "jane" (!username test-account))
+(test-equal #f (slot-bound? test-account 'omitted))
+(test-equal #f (!boolean test-account))
+
+;; Check idempotence
+(define test-account-idem (json->object <account> (object->json test-account)))
+(test-equal "11111" (!id test-account-idem))
+(test-equal "jane" (!username test-account-idem))
+(test-equal #f (slot-bound? test-account-idem 'omitted))
+(test-equal #f (!boolean test-account-idem))
+
+;; Class with nested record
+
+(define-json-mapping <link-record>
+  make-link
+  link?
+  json->link <=> link->json <=> scm->link <=> link->scm
+  (type link-type)
+  (url link-url))
+
+(define-class <account> (<comparable>)
+  (id       #:init-keyword #:id       #:accessor !id)
+  (username #:init-keyword #:username #:accessor !username)
+  (links    #:init-keyword #:links    #:accessor !links
+            #:json-serializer (lambda (v) (list->vector (map link->scm v)))
+            #:json-deserializer (lambda (v) (map scm->link (vector->list v)))))
+
+(define test-account
+  (make <account> #:id "11111" #:username "jane"
+        #:links (list (make-link "test" "http://guile.json"))))
+
+(test-equal "{\"id\":\"11111\",\"username\":\"jane\",\"links\":[{\"type\":\"test\",\"url\":\"http://guile.json\"}]}"
+  (object->json test-account))
+
+;; Check idempotence
+(test-equal (make <account> #:id "11111" #:username "jane"
+                  #:links (list (make-link "test" "http://guile.json")))
+  (json->object <account> (object->json test-account)))
+
+;; Class with nested class (de)serializer
+
+(define-class <link> (<comparable>)
+  (type #:init-keyword #:type)
+  (url  #:init-keyword #:url))
+
+(define-class <account> (<comparable>)
+  (id       #:init-keyword #:id       #:accessor !id)
+  (username #:init-keyword #:username #:accessor !username)
+  (links    #:init-keyword #:links    #:accessor !links
+            #:json-serializer (lambda (v) (list->vector (map object->scm v)))
+            #:json-deserializer (lambda (v) (map (lambda (i) (scm->object <link> i))
+                                                 (vector->list v)))))
+
+(define test-account
+  (make <account> #:id "11111" #:username "jane"
+        #:links (list (make <link> #:type "test" #:url "http://guile.json"))))
+
+(test-equal "{\"id\":\"11111\",\"username\":\"jane\",\"links\":[{\"type\":\"test\",\"url\":\"http://guile.json\"}]}"
+  (object->json test-account))
+
+;; Check idempotence
+(test-equal test-account
+  (json->object <account> (object->json test-account)))
+
+;; Class with nested class type
+
+(define-class <link-type> (<comparable>)
+  (type #:init-keyword #:type #:accessor !type)
+  (url  #:init-keyword #:url  #:accessor !url))
+
+(define-class <account-type> (<comparable>)
+  (id       #:init-keyword #:id       #:accessor !id)
+  (username #:init-keyword #:username #:accessor !username)
+  (link     #:init-keyword #:link     #:accessor !link #:type <link-type>))
+
+(define test-account-type
+  (make <account-type>
+    #:id "11111"
+    #:username "jane"
+    #:link (make <link-type> #:type "test" #:url "http://guile.json")))
+
+(test-equal "{\"id\":\"11111\",\"username\":\"jane\",\"link\":{\"type\":\"test\",\"url\":\"http://guile.json\"}}"
+  (object->json test-account-type))
+
+;; Check idempotence
+(test-equal test-account-type
+  (json->object <account-type> (object->json test-account-type)))
+
+;; Class with nested class type
+
+(define-class <link-type> (<comparable>)
+  (type #:init-keyword #:type #:accessor !type)
+  (url  #:init-keyword #:url  #:accessor !url))
+
+(define-class <account-type> (<comparable>)
+  (id       #:init-keyword #:id       #:accessor !id)
+  (username #:init-keyword #:username #:accessor !username)
+  (link     #:init-keyword #:link     #:accessor !link #:type <link-type>))
+
+(define test-account-type
+  (make <account-type>
+    #:id "11111"
+    #:username "jane"
+    #:link (make <link-type> #:type "test" #:url "http://guile.json")))
+
+(test-equal "{\"id\":\"11111\",\"username\":\"jane\",\"link\":{\"type\":\"test\",\"url\":\"http://guile.json\"}}"
+  (object->json test-account-type))
+
+;; Check idempotence
+(test-equal test-account-type
+  (json->object <account-type> (object->json test-account-type)))
+
+;; Class with vector type
+
+(define-class <account-type> (<comparable>)
+  (id       #:init-keyword #:id       #:accessor !id)
+  (username #:init-keyword #:username #:accessor !username)
+  (links    #:init-keyword #:link     #:accessor !link #:type (vector <link-type>)))
+
+(define test-account-type
+  (make <account-type> #:id "11111" #:username "jane"
+        #:link (vector (make <link-type> #:type "test" #:url "http://guile.json"))))
+
+(test-equal "{\"id\":\"11111\",\"username\":\"jane\",\"links\":[{\"type\":\"test\",\"url\":\"http://guile.json\"}]}"
+  (object->json test-account-type))
+
+;; Check idempotence with vectors
+(test-equal test-account-type
+  (json->object <account-type> (object->json test-account-type)))
+
+;; Class with list type
+
+(define-class <account-type> (<comparable>)
+  (id       #:init-keyword #:id       #:accessor !id)
+  (username #:init-keyword #:username #:accessor !username)
+  (links    #:init-keyword #:link     #:accessor !link #:type (list <link-type>)))
+
+(define test-account-type
+  (make <account-type> #:id "11111" #:username "jane"
+        #:link (list (make <link-type> #:type "test" #:url "http://guile.json"))))
+
+(test-equal "{\"id\":\"11111\",\"username\":\"jane\",\"links\":[{\"type\":\"test\",\"url\":\"http://guile.json\"}]}"
+  (object->json test-account-type))
+
+;; Check idempotence with lists
+(test-equal test-account-type
+  (json->object <account-type> (object->json test-account-type)))
+
+(let ((fail-count (test-runner-fail-count (test-runner-current))))
+  (test-end "test-record")
+  (exit (zero? fail-count)))
+
+;;; (tests test-record) ends here

--- a/tests/test-goops.scm
+++ b/tests/test-goops.scm
@@ -192,30 +192,6 @@
 (test-equal test-account-type
   (json->object <account-type> (object->json test-account-type)))
 
-;; Class with nested class type
-
-(define-class <link-type> (<comparable>)
-  (type #:init-keyword #:type #:accessor !type)
-  (url  #:init-keyword #:url  #:accessor !url))
-
-(define-class <account-type> (<comparable>)
-  (id       #:init-keyword #:id       #:accessor !id)
-  (username #:init-keyword #:username #:accessor !username)
-  (link     #:init-keyword #:link     #:accessor !link #:type <link-type>))
-
-(define test-account-type
-  (make <account-type>
-    #:id "11111"
-    #:username "jane"
-    #:link (make <link-type> #:type "test" #:url "http://guile.json")))
-
-(test-equal "{\"id\":\"11111\",\"username\":\"jane\",\"link\":{\"type\":\"test\",\"url\":\"http://guile.json\"}}"
-  (object->json test-account-type))
-
-;; Check idempotence
-(test-equal test-account-type
-  (json->object <account-type> (object->json test-account-type)))
-
 ;; Class with vector type
 
 (define-class <account-type> (<comparable>)


### PR DESCRIPTION
This PR adds support for mapping JSON documents to GOOPS classes, akin to the
document ↔ record support that is already present within guile-json. I have 
added the code and the tests, but I've yet to add the documentation in the
README.